### PR TITLE
fail when kubeadm init fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,8 @@ env:
     - ROLE_NAME: kubernetes
   matrix:
     - MOLECULE_DISTRO: centos7
-      MOLECULE_DOCKER_COMMAND: /usr/lib/systemd/systemd
-    - MOLECULE_DISTRO: ubuntu1604
-      MOLECULE_DOCKER_COMMAND: /lib/systemd/systemd
+    - MOLECULE_DISTRO: ubuntu1804
     - MOLECULE_DISTRO: debian9
-      MOLECULE_DOCKER_COMMAND: /lib/systemd/systemd
 
 install:
   # Install test dependencies.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Extra args to pass to `kubeadm init` during K8s control plane initialization. E.
 Whether to remove the taint that denies pods from being deployed to the Kubernetes master. If you have a single-node cluster, this should definitely be `True`. Otherwise, set to `False` if you want a dedicated Kubernetes master which doesn't run any other pods.
 
     kubernetes_enable_web_ui: false
+    kubernetes_web_ui_manifest_file: https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml
 
-Whether to enable the Kubernetes web dashboard UI (only accessible on the master itself, or proxied).
+Whether to enable the Kubernetes web dashboard UI (only accessible on the master itself, or proxied), and the file containing the web dashboard UI manifest.
 
     kubernetes_pod_network_cidr: '10.244.0.0/16'
     kubernetes_apiserver_advertise_address: ''

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Available variables are listed below, along with default values (see `defaults/m
 
 Kubernetes packages to be installed on the server. You can either provide a list of package names, or set `name` and `state` to have more control over whether the package is `present`, `absent`, `latest`, etc.
 
-    kubernetes_version: '1.11'
-    kubernetes_version_rhel_package: '1.11.3'
+    kubernetes_version: '1.13'
+    kubernetes_version_rhel_package: '1.13.1'
 
 The minor version of Kubernetes to install. The plain `kubernetes_version` is used to pin an apt package version on Debian, and as the Kubernetes version passed into the `kubeadm init` command (see `kubernetes_version_kubeadm`). The `kubernetes_version_rhel_package` variable must be a specific Kubernetes release, and is used to pin the version on Red Hat / CentOS servers.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Whether to remove the taint that denies pods from being deployed to the Kubernet
 
 Whether to enable the Kubernetes web dashboard UI (only accessible on the master itself, or proxied).
 
-    kuberenetes_debug: false
+    kubernetes_debug: false
 
 Whether to show extra debug info in Ansible's logs (e.g. the output of the `kubeadm init` command).
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,6 @@ Whether to remove the taint that denies pods from being deployed to the Kubernet
 
 Whether to enable the Kubernetes web dashboard UI (only accessible on the master itself, or proxied).
 
-    kubernetes_debug: false
-
-Whether to show extra debug info in Ansible's logs (e.g. the output of the `kubeadm init` command).
-
     kubernetes_pod_network_cidr: '10.244.0.0/16'
     kubernetes_apiserver_advertise_address: ''
     kubernetes_version_kubeadm: 'stable-{{ kubernetes_version }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ kubernetes_kubeadm_init_extra_opts: ""
 
 kubernetes_allow_pods_on_master: true
 kubernetes_enable_web_ui: true
-kuberenetes_debug: false
+kubernetes_debug: false
 
 kubernetes_pod_network_cidr: '10.244.0.0/16'
 kubernetes_apiserver_advertise_address: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,6 @@ kubernetes_kubeadm_init_extra_opts: ""
 
 kubernetes_allow_pods_on_master: true
 kubernetes_enable_web_ui: true
-kubernetes_debug: false
 
 kubernetes_pod_network_cidr: '10.244.0.0/16'
 kubernetes_apiserver_advertise_address: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,8 +9,8 @@ kubernetes_packages:
   - name: kubernetes-cni
     state: present
 
-kubernetes_version: '1.11'
-kubernetes_version_rhel_package: '1.11.3'
+kubernetes_version: '1.13'
+kubernetes_version_rhel_package: '1.13.1'
 
 kubernetes_role: master
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ kubernetes_kubeadm_init_extra_opts: ""
 
 kubernetes_allow_pods_on_master: true
 kubernetes_enable_web_ui: true
+kubernetes_web_ui_manifest_file: https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml
 
 kubernetes_pod_network_cidr: '10.244.0.0/16'
 kubernetes_apiserver_advertise_address: ''

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,11 +9,13 @@ lint:
     config-file: molecule/default/yaml-lint.yml
 platforms:
   - name: instance
-    image: geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible
-    command: ${MOLECULE_DOCKER_COMMAND:-"sleep infinity"}
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
       - /var/lib/docker
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,8 +14,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
       - /var/lib/docker
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
 provisioner:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -13,13 +13,18 @@
       apt: update_cache=true cache_valid_time=600
       when: ansible_os_family == 'Debian'
 
-    - name: Ensure test dependencies are installed.
+    - name: Ensure test dependencies are installed (RedHat).
       package: name=iproute state=present
+      when: ansible_os_family == 'RedHat'
+
+    - name: Ensure test dependencies are installed (Debian).
+      package: name=iproute2 state=present
+      when: ansible_os_family == 'Debian'
 
     - name: Gather facts.
       action: setup
 
-    - name: Use cgroupfs cgroup driver instead of systemd (Red Hat).
+    - name: Use cgroupfs cgroup driver instead of systemd (RedHat).
       set_fact:
         kubernetes_kubelet_extra_args: '"--fail-swap-on=false --cgroup-driver=cgroupfs"'
       when: ansible_os_family == 'RedHat'

--- a/tasks/kubelet-setup.yml
+++ b/tasks/kubelet-setup.yml
@@ -16,7 +16,7 @@
     kubelet_args_path: '/etc/systemd/system/kubelet.service.d/10-kubeadm.conf'
     kubelet_args_line: "{{ 'Environment=\"KUBELET_EXTRA_ARGS=' + kubernetes_kubelet_extra_args + '\"' }}"
     kubelet_args_regexp: '^Environment='
-  when: kubelet_environment_file.stat.exists == false
+  when: not kubelet_environment_file.stat.exists
 
 - name: Configure KUBELET_EXTRA_ARGS.
   lineinfile:

--- a/tasks/master-setup.yml
+++ b/tasks/master-setup.yml
@@ -15,7 +15,7 @@
 - name: Print the init output to screen.
   debug: var=kubeadmin_init.stdout
   when:
-    - kuberenetes_debug
+    - kubernetes_debug
     - kubernetes_init_stat.stat.exists == false
 
 - name: Ensure .kube directory exists.

--- a/tasks/master-setup.yml
+++ b/tasks/master-setup.yml
@@ -9,13 +9,6 @@
     {{ kubernetes_kubeadm_init_extra_opts }}
 
   register: kubeadmin_init
-  failed_when: false
-  when: not kubernetes_init_stat.stat.exists
-
-- name: Print the init output to screen.
-  debug:
-    var: kubeadmin_init.stdout
-    verbosity: 2
   when: not kubernetes_init_stat.stat.exists
 
 - name: Ensure .kube directory exists.

--- a/tasks/master-setup.yml
+++ b/tasks/master-setup.yml
@@ -10,13 +10,13 @@
 
   register: kubeadmin_init
   failed_when: false
-  when: kubernetes_init_stat.stat.exists == false
+  when: not kubernetes_init_stat.stat.exists
 
 - name: Print the init output to screen.
   debug:
     var: kubeadmin_init.stdout
     verbosity: 2
-  when: kubernetes_init_stat.stat.exists == false
+  when: not kubernetes_init_stat.stat.exists
 
 - name: Ensure .kube directory exists.
   file:
@@ -43,7 +43,7 @@
   command: "kubectl taint nodes --all node-role.kubernetes.io/master-"
   when:
     - kubernetes_allow_pods_on_master
-    - kubernetes_init_stat.stat.exists == false
+    - not kubernetes_init_stat.stat.exists
 
 - name: Check if Kubernetes Dashboard UI service already exists.
   shell: kubectl get services --namespace kube-system | grep -q kubernetes-dashboard
@@ -53,7 +53,7 @@
   when: kubernetes_enable_web_ui
 
 - name: Enable the Kubernetes Web Dashboard UI (if configured).
-  command: "kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml"
+  command: "kubectl create -f {{ kubernetes_web_ui_manifest_file }}"
   when:
     - kubernetes_enable_web_ui
     - kubernetes_dashboard_service is failed

--- a/tasks/master-setup.yml
+++ b/tasks/master-setup.yml
@@ -13,10 +13,10 @@
   when: kubernetes_init_stat.stat.exists == false
 
 - name: Print the init output to screen.
-  debug: var=kubeadmin_init.stdout
-  when:
-    - kubernetes_debug
-    - kubernetes_init_stat.stat.exists == false
+  debug:
+    var: kubeadmin_init.stdout
+    verbosity: 2
+  when: kubernetes_init_stat.stat.exists == false
 
 - name: Ensure .kube directory exists.
   file:

--- a/tasks/node-setup.yml
+++ b/tasks/node-setup.yml
@@ -3,3 +3,4 @@
   shell: >
     {{ kubernetes_join_command }}
     creates=/etc/kubernetes/kubelet.conf
+  tags: ['skip_ansible_lint']


### PR DESCRIPTION
see https://github.com/geerlingguy/ansible-role-kubernetes/issues/28

result (here with a non-existing kubernetes-version):
```
[...]
TASK [kubernetes : Initialize Kubernetes master with kubeadm init.] *************************
fatal: [eins.mbr.intern]: FAILED! => {"changed": true, "cmd": ["kubeadm", "init", "--pod-network-cidr=10.244.0.0/16", "--apiserver-advertise-address=", "--kubernetes-version", "stable-1.13.", "--ignore-preflight-errors=all"], "delta": "0:00:01.073684", "end": "2019-01-02 14:39:41.933897", "msg": "non-zero return code", "rc": 1, "start": "2019-01-02 14:39:40.860213", "stderr": "unable to fetch file. URL: \"https://dl.k8s.io/release/stable-1.13..txt\", status: 404 Not Found", "stderr_lines": ["unable to fetch file. URL: \"https://dl.k8s.io/release/stable-1.13..txt\", status: 404 Not Found"], "stdout": "", "stdout_lines": []}

NO MORE HOSTS LEFT **************************************************************************
        to retry, use: --limit @/home/marc/infrastructure/kubernetes/playbooks/mbr.debug.retry
```
