### PR TITLE
Kube-Router support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Whether to remove the taint that denies pods from being deployed to the Kubernet
 
 Whether to enable the Kubernetes web dashboard UI (only accessible on the master itself, or proxied), and the file containing the web dashboard UI manifest.
 
+    kubernetes_pod_network_plugin: 'flannel'
+
+Pod network plugin to use, otherwise called a container network interface (CNI).  Supported options are `flannel` and `kube-router`
+
     kubernetes_pod_network_cidr: '10.244.0.0/16'
     kubernetes_apiserver_advertise_address: ''
     kubernetes_version_kubeadm: 'stable-{{ kubernetes_version }}'
@@ -72,6 +76,11 @@ Yum repository options for Kubernetes installation.
     kubernetes_flannel_manifest_file: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 
 Flannel manifest files to apply to the Kubernetes cluster to enable networking. You can copy your own files to your server and apply them instead, if you need to customize the Flannel networking configuration.
+
+    kubernetes_kuberouter_manifest_file: https://raw.githubusercontent.com/cloudnativelabs/kube-router/master/daemonset/kubeadm-kuberouter-all-features.yaml
+    kubernetes_kubeproxy_version: '1.10.2'
+
+Kube-Router manifest file to apply to the Kubernetes cluster to enable Kube-Router networking.  This is activated by setting `kubernetes_pod_network_plugin: 'kube-router'`
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ kubernetes_allow_pods_on_master: true
 kubernetes_enable_web_ui: true
 kubernetes_web_ui_manifest_file: https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml
 
+kubernetes_pod_network_plugin: 'flannel'
 kubernetes_pod_network_cidr: '10.244.0.0/16'
 kubernetes_apiserver_advertise_address: ''
 kubernetes_version_kubeadm: 'stable-{{ kubernetes_version }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,3 +37,7 @@ kubernetes_yum_arch: x86_64
 # Flannel config files.
 kubernetes_flannel_manifest_file_rbac: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/k8s-manifests/kube-flannel-rbac.yml
 kubernetes_flannel_manifest_file: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+# Kube-Router config files.
+kubernetes_kuberouter_manifest_file: >-
+  https://raw.githubusercontent.com/cloudnativelabs/kube-router/master/daemonset/kubeadm-kuberouter-all-features.yaml
+kubernetes_kubeproxy_version: '1.10.2'

--- a/tasks/master-setup.yml
+++ b/tasks/master-setup.yml
@@ -29,14 +29,6 @@
     dest: ~/.kube/config
     state: link
 
-- name: Configure Flannel networking.
-  command: "{{ item }}"
-  with_items:
-    - kubectl apply -f {{ kubernetes_flannel_manifest_file_rbac }}
-    - kubectl apply -f {{ kubernetes_flannel_manifest_file }}
-  register: flannel_result
-  changed_when: "'created' in flannel_result.stdout"
-
 # TODO: Check if taint exists with something like `kubectl describe nodes`
 # instead of using kubernetes_init_stat.stat.exists check.
 - name: Allow pods on master node (if configured).
@@ -44,6 +36,10 @@
   when:
     - kubernetes_allow_pods_on_master
     - not kubernetes_init_stat.stat.exists
+
+# Set up pod network.
+- include_tasks: pod-network.yml
+  when: not kubernetes_init_stat.stat.exists
 
 - name: Check if Kubernetes Dashboard UI service already exists.
   shell: kubectl get services --namespace kube-system | grep -q kubernetes-dashboard

--- a/tasks/pod-network.yml
+++ b/tasks/pod-network.yml
@@ -7,3 +7,15 @@
   register: flannel_result
   when: kubernetes_pod_network_plugin == 'flannel'
   changed_when: "'created' in flannel_result.stdout"
+
+- name: Configure Kube-router networking.
+  command: "{{ item }}"
+  with_items:
+    - kubectl apply -f {{ kubernetes_kuberouter_manifest_file }}
+    - kubectl -n kube-system delete ds kube-proxy
+    - >-
+        docker run --privileged -v /lib/modules:/lib/modules --net=host
+        k8s.gcr.io/kube-proxy-amd64:v{{ kubernetes_kubeproxy_version }} kube-proxy --cleanup
+  register: kuberouter_result
+  when: kubernetes_pod_network_plugin == 'kube-router'
+  changed_when: "'created' in kuberouter_result.stdout"

--- a/tasks/pod-network.yml
+++ b/tasks/pod-network.yml
@@ -1,0 +1,9 @@
+---
+- name: Configure Flannel networking.
+  command: "{{ item }}"
+  with_items:
+    - kubectl apply -f {{ kubernetes_flannel_manifest_file_rbac }}
+    - kubectl apply -f {{ kubernetes_flannel_manifest_file }}
+  register: flannel_result
+  when: kubernetes_pod_network_plugin == 'flannel'
+  changed_when: "'created' in flannel_result.stdout"


### PR DESCRIPTION
This allows `kube-router` pod network to be installed by specifying
```
kubernetes_pod_network_plugin: 'kube-router'
```

https://github.com/cloudnativelabs/kube-router/blob/master/docs/kubeadm.md