### PR TITLE
Logic to prevent preflight error when doing kubeadm join on centos

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,3 +36,6 @@ kubernetes_yum_arch: x86_64
 # Flannel config files.
 kubernetes_flannel_manifest_file_rbac: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/k8s-manifests/kube-flannel-rbac.yml
 kubernetes_flannel_manifest_file: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+
+# Location of the file that is used to enable bridge-nf-call tables for nodes
+sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"

--- a/tasks/node-setup.yml
+++ b/tasks/node-setup.yml
@@ -1,4 +1,31 @@
 ---
+
+- block:
+
+  - name: Check if bridge-nf-call-iptables key exists
+    command: "sysctl net.bridge.bridge-nf-call-iptables"
+    failed_when: false
+    changed_when: false
+    register: sysctl_bridge_nf_call_iptables
+
+  - name: Enable bridge-nf-call tables
+    sysctl:
+      name: "{{ item }}"
+      state: present
+      sysctl_file: "{{ sysctl_file_path }}"
+      value: 1
+      reload: yes
+    when: sysctl_bridge_nf_call_iptables.rc == 0
+    loop:
+      - net.bridge.bridge-nf-call-iptables
+      - net.bridge.bridge-nf-call-arptables
+      - net.bridge.bridge-nf-call-ip6tables
+
+  when: ansible_os_family == 'RedHat'
+  become: yes
+  become_user: root
+  become_method: sudo
+
 - name: Join node to Kubernetes master
   shell: >
     {{ kubernetes_join_command }}


### PR DESCRIPTION
The changes in this PR will prevent this error when creating a cluster with CentOS nodes: https://github.com/geerlingguy/ansible-role-kubernetes/issues/38

It is exactly what kubespray does, as you can see here: https://github.com/kubernetes-sigs/kubespray/blob/master/roles/kubernetes/node/tasks/main.yml#L86