### PR TITLE
Allow specifying repo baseurl and gpgkey

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,9 +29,15 @@ kubernetes_ignore_preflight_errors: 'all'
 kubernetes_apt_release_channel: main
 # Note that xenial repo is used for all Debian derivatives at this time.
 kubernetes_apt_repository: "deb http://apt.kubernetes.io/ kubernetes-xenial {{ kubernetes_apt_release_channel }}"
+kubernetes_apt_gpgkey: https://packages.cloud.google.com/apt/doc/apt-key.gpg
 kubernetes_apt_ignore_key_error: false
 
 kubernetes_yum_arch: x86_64
+kubernetes_yum_baseurl: 'https://packages.cloud.google.com/yum/repos/kubernetes-el7-{{ kubernetes_yum_arch }}'
+kubernetes_yum_repo_gpgcheck: true
+kubernetes_yum_gpgkey:
+  - https://packages.cloud.google.com/yum/doc/yum-key.gpg
+  - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 
 # Flannel config files.
 kubernetes_flannel_manifest_file_rbac: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/k8s-manifests/kube-flannel-rbac.yml

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -8,7 +8,7 @@
 
 - name: Add Kubernetes apt key.
   apt_key:
-    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    url: "{{ kubernetes_apt_gpgkey }}"
     state: present
   register: add_repository_key
   ignore_errors: "{{ kubernetes_apt_ignore_key_error }}"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -5,20 +5,16 @@
     description: Kubernetes
     enabled: true
     gpgcheck: true
-    repo_gpgcheck: true
-    baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-{{ kubernetes_yum_arch }}
-    gpgkey:
-      - https://packages.cloud.google.com/yum/doc/yum-key.gpg
-      - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+    repo_gpgcheck: '{{ kubernetes_yum_repo_gpgcheck }}'
+    baseurl: '{{ kubernetes_yum_baseurl }}'
+    gpgkey: '{{ kubernetes_yum_gpgkey | join(" ") }}'
 
 - name: Add Kubernetes GPG keys.
   rpm_key:
     key: "{{ item }}"
     state: present
   register: kubernetes_rpm_key
-  with_items:
-    - https://packages.cloud.google.com/yum/doc/yum-key.gpg
-    - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+  with_items: '{{ kubernetes_yum_gpgkey }}'
 
 - name: Make cache if Kubernetes GPG key changed.
   command: "yum -q makecache -y --disablerepo='*' --enablerepo='kubernetes'"


### PR DESCRIPTION
Variable `kubernetes_yum_repo_gpgcheck` is added because it happens that
gpg command on Amazon Linux can fail verifying repomd.xml while working
alright with package signatures.  See [1] for details

[1] https://github.com/kubernetes/kubernetes/issues/60134#issuecomment-498897967