### PR TITLE
setting join group to a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Extra args to pass to `kubeadm init` during K8s control plane initialization. E.
 
 Extra args to pass to the generated `kubeadm join` command during K8s node initialization. E.g. to ignore certain preflight errors like swap being enabled, set this to: `--ignore-preflight-errors=Swap`
 
+    kubernetes_join_group: 'all'
+
+The scope to which group the join command will be applied.  The default is set to 'all' but you may want to specify a specific group if there are more than one cluster in an inventory (in which case `kubernetes_role` may be defined in separate clusters, which are not relevant to a particular execution).
+
     kubernetes_allow_pods_on_master: true
 
 Whether to remove the taint that denies pods from being deployed to the Kubernetes master. If you have a single-node cluster, this should definitely be `True`. Otherwise, set to `False` if you want a dedicated Kubernetes master which doesn't run any other pods.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ kubernetes_role: master
 kubernetes_kubelet_extra_args: ""
 kubernetes_kubeadm_init_extra_opts: ""
 kubernetes_join_command_extra_opts: ""
+kubernetes_join_group: 'all'
 
 kubernetes_allow_pods_on_master: true
 kubernetes_enable_web_ui: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,7 +50,7 @@
   when: kubernetes_join_command_result.stdout is defined
   delegate_to: "{{ item }}"
   delegate_facts: true
-  with_items: "{{ groups['all'] }}"
+  with_items: "{{ groups[kubernetes_join_group] }}"
 
 - include_tasks: node-setup.yml
   when: kubernetes_role == 'node'


### PR DESCRIPTION
Thanks! this is a nice role to get started with deploying a simple Kubernetes cluster using Ansible and was just what I was looking for.  I have also just bought [Ansible for Kubernetes](https://leanpub.com/ansible-for-kubernetes) so am looking forward to reading through that.

The issue that I encountered using this role is that if an inventory has multiple clusters then the hard-coded `all` group reference causes issues where inventory items that have the `kubernetes_role` variable already defined, but out of scope of the current deployment, to be picked up.  This PR just simply adds a variable so that an alternate group can be specified: `kubernetes_join_group` (which defaults to 'all').  This then allows me to pass in that group and to limit scope.