### PR TITLE
Fix bool logic to install k8s dashboard

### DIFF
--- a/tasks/master-setup.yml
+++ b/tasks/master-setup.yml
@@ -63,4 +63,4 @@
   command: "kubectl create -f {{ kubernetes_web_ui_manifest_file }}"
   when:
     - kubernetes_enable_web_ui | bool
-    - kubernetes_dashboard_service.stdout == ""
+    - not kubernetes_dashboard_service.stdout | bool

--- a/tasks/master-setup.yml
+++ b/tasks/master-setup.yml
@@ -63,4 +63,4 @@
   command: "kubectl create -f {{ kubernetes_web_ui_manifest_file }}"
   when:
     - kubernetes_enable_web_ui | bool
-    - kubernetes_dashboard_service is failed
+    - kubernetes_dashboard_service.stdout == ""


### PR DESCRIPTION
The logic to determine whether to install the K8S dashboard or not, was not working and is fixed by this PR.