### PR TITLE
Adding settings to sysctl for bridging

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,20 @@
   notify: restart kubelet
   with_items: "{{ kubernetes_packages }}"
 
+# per the install doc, 
+# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/
+- name: Set sysctl for IPv4 bridges
+  sysctl:
+    name: net.bridge.bridge-nf-call-iptables
+    value: 1
+    state: present
+
+- name: Set sysctl for IPv6 bridges
+  sysctl:
+    name: net.bridge.bridge-nf-call-ip6tables
+    value: 1
+    state: present
+
 - include_tasks: kubelet-setup.yml
 
 - name: Ensure kubelet is started and enabled at boot.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,13 +23,13 @@
 - name: Set sysctl for IPv4 bridges
   sysctl:
     name: net.bridge.bridge-nf-call-iptables
-    value: 1
+    value: '1'
     state: present
 
 - name: Set sysctl for IPv6 bridges
   sysctl:
     name: net.bridge.bridge-nf-call-ip6tables
-    value: 1
+    value: '1'
     state: present
 
 - include_tasks: kubelet-setup.yml


### PR DESCRIPTION
Per the install doc on the kubernetes site: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#letting-iptables-see-bridged-traffic

Adding sysctl entries for bridging