### PR TITLE
Add proxy option for YUM keys

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -19,6 +19,8 @@
   with_items:
     - https://packages.cloud.google.com/yum/doc/yum-key.gpg
     - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+  environment:
+    https_proxy: "{{ kubernetes_yum_key_https_proxy | default(ansible_env.https_proxy | default('')) }}"
 
 - name: Make cache if Kubernetes GPG key changed.
   command: "yum -q makecache -y --disablerepo='*' --enablerepo='kubernetes'"


### PR DESCRIPTION
Kubernetes GPG keys are not accessible without a proper proxy in China. However, setting a `https_proxy` envvar for the whole role would not work since it somehow also affects proxies in Kubernetes. Thus making it possible to configure proxy solely for GPG keys may be the only way to go.

With this patch, by giving `kubernetes_yum_key_https_proxy` a proper value, one can access the GPG keys with help of the proxy. For users don't need proxies, just leave it as is and this patch will affect nothing.