### PR TITLE
update sysctl to 2.10

### DIFF
--- a/tasks/sysctl-setup.yml
+++ b/tasks/sysctl-setup.yml
@@ -9,7 +9,7 @@
 
 # See: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#letting-iptables-see-bridged-traffic
 - name: Let iptables see bridged traffic.
-  sysctl:
+  ansible.posix.sysctl:
     name: "{{ item }}"
     value: '1'
     state: present


### PR DESCRIPTION
In Ansible version 2.10 sysctl was moved to the [ansbile.posix](https://galaxy.ansible.com/ansible/posix) collection.

If Ansible 2.10 is used, it is required to run `ansible-galaxy collection install ansible.posix` and use `ansible.posix.sysctl` within the playbook.

[Ansible Github issue](https://github.com/ansible/ansible/issues/68416)