### PR TITLE
fix the condition to enable Kubernetes Dashboard

### DIFF
--- a/tasks/master-setup.yml
+++ b/tasks/master-setup.yml
@@ -79,4 +79,4 @@
   command: "kubectl create -f {{ kubernetes_web_ui_manifest_file }}"
   when:
     - kubernetes_enable_web_ui | bool
-    - kubernetes_dashboard_service is failed
+    - kubernetes_dashboard_service.rc != 0


### PR DESCRIPTION
`kubernetes_dashboard_service `will not be failed, because the `fail_when` was set as `false` in the task of checking the dashboard service