### PR TITLE
Make gpgcheck and repo_gpgcheck configurable for yum

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Apt repository options for Kubernetes installation.
       - https://packages.cloud.google.com/yum/doc/yum-key.gpg
       - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
     kubernetes_gpg_check: true
-    kubernetes_repo_gpg_check: true
+    kubernetes_repo_gpg_check: false
 
 Yum repository options for Kubernetes installation. You can change `kubernete_yum_gpg_key` to a different url if you are behind a firewall or provide a trustworthy mirror. Usually in combination with changing `kubernetes_yum_base_url` as well.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Apt repository options for Kubernetes installation.
     kubernetes_yum_gpg_key:
       - https://packages.cloud.google.com/yum/doc/yum-key.gpg
       - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+    kubernetes_gpg_check: true
+    kubernetes_repo_gpg_check: true
 
 Yum repository options for Kubernetes installation. You can change `kubernete_yum_gpg_key` to a different url if you are behind a firewall or provide a trustworthy mirror. Usually in combination with changing `kubernetes_yum_base_url` as well.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,8 @@ kubernetes_yum_base_url: "https://packages.cloud.google.com/yum/repos/kubernetes
 kubernetes_yum_gpg_key:
   - https://packages.cloud.google.com/yum/doc/yum-key.gpg
   - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+kubernetes_gpg_check: true
+kubernetes_repo_gpg_check: true
 
 # Flannel config files.
 kubernetes_flannel_manifest_file_rbac: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/k8s-manifests/kube-flannel-rbac.yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,7 +45,7 @@ kubernetes_yum_gpg_key:
   - https://packages.cloud.google.com/yum/doc/yum-key.gpg
   - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 kubernetes_gpg_check: true
-kubernetes_repo_gpg_check: true
+kubernetes_repo_gpg_check: false
 
 # Flannel config files.
 kubernetes_flannel_manifest_file_rbac: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/k8s-manifests/kube-flannel-rbac.yml

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -4,8 +4,8 @@
     name: kubernetes
     description: Kubernetes
     enabled: true
-    gpgcheck: true
-    repo_gpgcheck: true
+    gpgcheck: "{{ kubernetes_gpg_check }}"
+    repo_gpgcheck: "{{ kubernetes_repo_gpg_check }}"
     baseurl: "{{ kubernetes_yum_base_url }}"
     gpgkey: "{{ kubernetes_yum_gpg_key }}"
 


### PR DESCRIPTION
At the time of this PR, this role is currently failing on CentOS 7 distros with a `repomd.xml signature could not be verified for kubernetes` error. 

This appears to be an upstream issue, and an issue that unfortunately crops up somewhat often. However, it can be worked around with a change to make some yum_repository options configurable. See [here](https://github.com/kubernetes/kubernetes/issues/60134), also [here](https://github.com/kubernetes/release/issues/1982), and most importantly see the official suggestion from Google [here](https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired)

This PR makes gpgcheck and repo_gpgcheck configurable so that they can be changed. Setting repo_gpgcheck to 'false' prevents the "signature could not be verified for kubernetes" issue.