### PR TITLE
Add cilium CNI

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,3 +51,6 @@ kubernetes_flannel_manifest_file: https://raw.githubusercontent.com/coreos/flann
 
 # Calico config files
 kubernetes_calico_manifest_file: https://docs.projectcalico.org/v3.10/manifests/calico.yaml
+
+# Cilium config files
+kubernetes_cilium_manifest_file: https://raw.githubusercontent.com/cilium/cilium/v1.9/install/kubernetes/quick-install.yaml

--- a/tasks/master-setup.yml
+++ b/tasks/master-setup.yml
@@ -60,6 +60,39 @@
   changed_when: "'created' in weave_result.stdout"
   when: kubernetes_pod_network.cni == 'weave'
 
+- name: Create temporary directory for Cilium kustomization.
+  tempfile:
+    state: directory
+    prefix: "cilium-kustomize."
+  register: cilium_kustomize_dir
+  when: kubernetes_pod_network.cni == 'cilium'
+
+- name: Get cilium manifest.
+  get_url:
+    url: "{{ kubernetes_cilium_manifest_file }}"
+    dest: "{{ cilium_kustomize_dir.path }}/cilium.yaml"
+  when: kubernetes_pod_network.cni == 'cilium'
+
+- name: Add cilium kustomization.yaml.
+  template:
+    src: "cilium-kustomization.yaml"
+    dest: "{{ cilium_kustomize_dir.path }}/kustomization.yaml"
+  when: kubernetes_pod_network.cni == 'cilium'
+
+- name: Add cilium patch.yaml.
+  template:
+    src: "cilium-patch.yaml"
+    dest: "{{ cilium_kustomize_dir.path }}/patch.yaml"
+  when: kubernetes_pod_network.cni == 'cilium'
+
+- name: Configure Cilium networking.
+  command: "{{ item }}"
+  with_items:
+    - kubectl apply -k {{ cilium_kustomize_dir.path }}
+  register: cilium_result
+  changed_when: "'created' in cilium_result.stdout"
+  when: kubernetes_pod_network.cni == 'cilium'
+
 # TODO: Check if taint exists with something like `kubectl describe nodes`
 # instead of using kubernetes_init_stat.stat.exists check.
 - name: Allow pods on master node (if configured).

--- a/templates/cilium-kustomization.yaml
+++ b/templates/cilium-kustomization.yaml
@@ -1,9 +1,10 @@
+---
 resources:
-- cilium.yaml
+  - cilium.yaml
 
 patchesJson6902:
-- path: patch.yaml
-  target:
-    version: v1
-    kind: ConfigMap
-    name: cilium-config
+  - path: patch.yaml
+    target:
+      version: v1
+      kind: ConfigMap
+      name: cilium-config

--- a/templates/cilium-kustomization.yaml
+++ b/templates/cilium-kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- cilium.yaml
+
+patchesJson6902:
+- path: patch.yaml
+  target:
+    version: v1
+    kind: ConfigMap
+    name: cilium-config

--- a/templates/cilium-patch.yaml
+++ b/templates/cilium-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /data/cluster-pool-ipv4-cidr
+  value: "{{ kubernetes_pod_network.cidr }}"

--- a/templates/cilium-patch.yaml
+++ b/templates/cilium-patch.yaml
@@ -1,3 +1,4 @@
+---
 - op: replace
   path: /data/cluster-pool-ipv4-cidr
   value: "{{ kubernetes_pod_network.cidr }}"


### PR DESCRIPTION
This PR adds support of `Cilium CNI` using [Quick Installation](https://docs.cilium.io/en/v1.9/gettingstarted/k8s-install-default/) method. 

One of the problems with this method is the hardcoded pool of addresses for pods. I am using kustomize to fix it. Works well on `1.16`, `1.19` and `1.20`