### PR TITLE
Add way to configure KubeProxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ NOTE: This is the recommended way to do the kubelet-configuration. Most command-
 
 NOTE: The recommended cgroupDriver depends on your [Container Runtime](https://kubernetes.io/docs/setup/production-environment/container-runtimes). When using this role with containerd instead of docker, this value should be changed to `systemd`.
 
+    kubernetes_config_kube_proxy_configuration: {}
+
+Options under `kind: KubeProxyConfiguration`.
+
 ### Variables to configure kubeadm and kubelet through command-line-options
 
     kubernetes_kubelet_extra_args: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,8 @@ kubernetes_config_cluster_configuration:
     podSubnet: "{{ kubernetes_pod_network.cidr }}"
   kubernetesVersion: "{{ kubernetes_version_kubeadm }}"
 
+kubernetes_config_kube_proxy_configuration: {}
+
 kubernetes_apiserver_advertise_address: ''
 kubernetes_version_kubeadm: 'stable-{{ kubernetes_version }}'
 kubernetes_ignore_preflight_errors: 'all'

--- a/templates/kubeadm-kubelet-config.j2
+++ b/templates/kubeadm-kubelet-config.j2
@@ -6,9 +6,15 @@ kind: InitConfiguration
 kind: ClusterConfiguration
 apiVersion: kubeadm.k8s.io/v1beta2
 {{ kubernetes_config_cluster_configuration | to_nice_yaml }}
----
 {% if kubernetes_config_kubelet_configuration|length > 0 %}
+---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 {{ kubernetes_config_kubelet_configuration | to_nice_yaml }}
+{% endif %}
+{% if kubernetes_config_kube_proxy_configuration|length > 0 %}
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+{{ kubernetes_config_kube_proxy_configuration | to_nice_yaml }}
 {% endif %}


### PR DESCRIPTION
Hi 👋 

This PR add the [KubeProxy section of the kubeadm config file](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/#basics) (it can be useful if you want to change the bind-address of kube-proxy to expose the metrics to prometheus for example).

Have a great day :) (Also, keep publishing content on YT, it's dope)