### PR TITLE
Update Calico manifest URL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,4 +70,4 @@ kubernetes_flannel_manifest_file_rbac: https://raw.githubusercontent.com/coreos/
 kubernetes_flannel_manifest_file: https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 
 # Calico config files
-kubernetes_calico_manifest_file: https://docs.projectcalico.org/v3.10/manifests/calico.yaml
+kubernetes_calico_manifest_file: https://projectcalico.docs.tigera.io/manifests/calico.yaml


### PR DESCRIPTION
The current Calico manifest URL (https://docs.projectcalico.org/v3.10/manifests/calico.yaml) errors out with various deprecations errors; updating var value to current URL found in Calico install docs (https://projectcalico.docs.tigera.io/getting-started/kubernetes/self-managed-onprem/onpremises) fixes issues in the calling play and runs fine.