### PR TITLE
Dynamically untaint node, fix sysctl for Ubuntu 22.04

### DIFF
--- a/tasks/master-setup.yml
+++ b/tasks/master-setup.yml
@@ -76,10 +76,24 @@
   changed_when: "'created' in weave_result.stdout"
   when: kubernetes_pod_network.cni == 'weave'
 
-# TODO: Check if taint exists with something like `kubectl describe nodes`
-# instead of using kubernetes_init_stat.stat.exists check.
-- name: Allow pods on master node (if configured).
-  command: "kubectl taint nodes --all node-role.kubernetes.io/master-"
+# Check if a Taint exists
+- name: Check if taint exists preventing pods to be scheduled on the master node
+  shell: |
+    set -o pipefail
+    kubectl describe nodes | grep Taints | grep --invert-match \<none\>  | sed -r 's/Taints:\s+(.*:NoSchedule)/\1/'
+  args:
+    executable: /bin/bash
+  register: kube_taint
+  # grep will exit with 1 when no results found.
+  # This causes the task not to halt play.
+  ignore_errors: true
+  changed_when: false
   when:
     - kubernetes_allow_pods_on_master | bool
-    - not kubernetes_init_stat.stat.exists
+
+# Untaint node depending on previous result
+- name: Allow pods on master node (if configured).
+  command: "kubectl taint nodes --all {{ kube_taint.stdout }}-"
+  when:
+    - kubernetes_allow_pods_on_master | bool
+    - not kube_taint.failed

--- a/tasks/sysctl-setup.yml
+++ b/tasks/sysctl-setup.yml
@@ -7,11 +7,19 @@
     ansible_distribution != 'Debian'
     or ansible_distribution_major_version | int < 10
 
-# See: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#letting-iptables-see-bridged-traffic
+# See: https://kubernetes.io/docs/setup/production-environment/container-runtimes/#forwarding-ipv4-and-letting-iptables-see-bridged-traffic
+- name: Ensure br_netfilter is loaded
+  community.general.modprobe:
+    name: br_netfilter
+    state: present
+  when: >
+    ansible_distribution != 'Debian'
+    or ansible_distribution_major_version | int < 10
+
 - name: Let iptables see bridged traffic.
   sysctl:
     name: "{{ item }}"
-    value: '1'
+    value: "1"
     state: present
   loop:
     - net.bridge.bridge-nf-call-iptables


### PR DESCRIPTION
This PR introduces two changes:

- If the master node needs to be untainted, it now checks for a Taint with NoSchedule before executing a change. This also covers other versions (e.g. 1.25) so the Taint compared to the currently hardcoded version, such as `node-role.kubernetes.io/control-plane:NoSchedule`
- Fixed the link towards the bridged traffic documentation, as it was moved
- Make sure the `br_netfilter` module is loaded before attempting a redirect of traffic

Note that the check for Tainted attributes uses the `shell` executor with a `pipefail` option, which assumes bash to be available. Not sure of that is fine or if another solution is required.