### PR TITLE
Improve sysctl-setup.yml for Ubuntu

### DIFF
--- a/tasks/sysctl-setup.yml
+++ b/tasks/sysctl-setup.yml
@@ -5,7 +5,7 @@
     modprobe:
       name: br_netfilter
       state: present
-    when: (ansible_os_family | lower) == "ubuntu"
+    when: ansible_distribution == "Debian"
 
   - name: Ensure procps is installed.
     package:

--- a/tasks/sysctl-setup.yml
+++ b/tasks/sysctl-setup.yml
@@ -5,7 +5,7 @@
     modprobe:
       name: br_netfilter
       state: present
-    when: ansible_distribution == "Debian"
+    when: (ansible_os_family | lower) == "ubuntu"
 
   - name: Ensure procps is installed.
     package:

--- a/tasks/sysctl-setup.yml
+++ b/tasks/sysctl-setup.yml
@@ -1,11 +1,11 @@
 ---
 - block:
-  
+
   - name: Enable br_netfilter module
     modprobe:
       name: br_netfilter
       state: present
-  
+
   - name: Ensure procps is installed.
     package:
       name: "{{ procps_package }}"
@@ -27,7 +27,7 @@
     when: >
       ansible_distribution != 'Debian'
       or ansible_distribution_major_version | int < 10
-      
+
   become: yes
   become_user: root
   become_method: sudo

--- a/tasks/sysctl-setup.yml
+++ b/tasks/sysctl-setup.yml
@@ -1,21 +1,33 @@
 ---
-- name: Ensure procps is installed.
-  package:
-    name: "{{ procps_package }}"
-    state: present
-  when: >
-    ansible_distribution != 'Debian'
-    or ansible_distribution_major_version | int < 10
+- block:
+  
+  - name: Enable br_netfilter module
+    modprobe:
+      name: br_netfilter
+      state: present
+  
+  - name: Ensure procps is installed.
+    package:
+      name: "{{ procps_package }}"
+      state: present
+    when: >
+      ansible_distribution != 'Debian'
+      or ansible_distribution_major_version | int < 10
 
-# See: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#letting-iptables-see-bridged-traffic
-- name: Let iptables see bridged traffic.
-  sysctl:
-    name: "{{ item }}"
-    value: '1'
-    state: present
-  loop:
-    - net.bridge.bridge-nf-call-iptables
-    - net.bridge.bridge-nf-call-ip6tables
-  when: >
-    ansible_distribution != 'Debian'
-    or ansible_distribution_major_version | int < 10
+  # See: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#letting-iptables-see-bridged-traffic
+  - name: Let iptables see bridged traffic.
+    sysctl:
+      name: "{{ item }}"
+      value: '1'
+      state: present
+    loop:
+      - net.ipv4.ip_forward
+      - net.bridge.bridge-nf-call-iptables
+      - net.bridge.bridge-nf-call-ip6tables
+    when: >
+      ansible_distribution != 'Debian'
+      or ansible_distribution_major_version | int < 10
+      
+  become: yes
+  become_user: root
+  become_method: sudo

--- a/tasks/sysctl-setup.yml
+++ b/tasks/sysctl-setup.yml
@@ -5,6 +5,7 @@
     modprobe:
       name: br_netfilter
       state: present
+    when: ansible_distribution == "Debian"
 
   - name: Ensure procps is installed.
     package:


### PR DESCRIPTION
This PR improves sysctl-setup.yml so that this role can successfully run against Ubuntu. Prior to these changes, sysctl would fail with 'No such file or directory' on Ubuntu during the "Let iptables see bridged traffic" task.

The main changes here are:

- Enabling the br_netfilter module
- Enabling net.ipv4.ip_forward
- Wrapping the calls in a become block, required for execution

Both br_netfilter and net.ipv4.ip_forward are both explicitly called out [here](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#forwarding-ipv4-and-letting-iptables-see-bridged-traffic) in the k8s docs. This role does not work against at least Ubuntu 20.04 instances without these changes