### PR TITLE
Enable br_netfilter module for Ubuntu

### DIFF
--- a/tasks/sysctl-setup.yml
+++ b/tasks/sysctl-setup.yml
@@ -7,6 +7,14 @@
     ansible_distribution != 'Debian'
     or ansible_distribution_major_version | int < 10
 
+- name: Enable br_netfilter module
+  modprobe:
+    name: br_netfilter
+    state: present
+  when: >
+    ansible_distribution != 'Debian'
+    or ansible_distribution_major_version | int < 10
+
 # See: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#letting-iptables-see-bridged-traffic
 - name: Let iptables see bridged traffic.
   sysctl:

--- a/tasks/sysctl-setup.yml
+++ b/tasks/sysctl-setup.yml
@@ -15,7 +15,7 @@
     ansible_distribution != 'Debian'
     or ansible_distribution_major_version | int < 10
 
-# See: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#letting-iptables-see-bridged-traffic
+# See: https://kubernetes.io/docs/setup/production-environment/container-runtimes/#forwarding-ipv4-and-letting-iptables-see-bridged-traffic
 - name: Let iptables see bridged traffic.
   sysctl:
     name: "{{ item }}"
@@ -24,6 +24,7 @@
   loop:
     - net.bridge.bridge-nf-call-iptables
     - net.bridge.bridge-nf-call-ip6tables
+    - net.ipv4.ip_forward
   when: >
     ansible_distribution != 'Debian'
     or ansible_distribution_major_version | int < 10


### PR DESCRIPTION
The https://github.com/geerlingguy/ansible-role-kubernetes/issues/92#issuecomment-983357881 have been implemented.




There are similar PRs https://github.com/geerlingguy/ansible-role-kubernetes/pull/135 , but I were created as different PRs because they have different DISTRIBUTION.