### PR TITLE
Update setup-Debian.yml

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -24,3 +24,9 @@
     src: apt-preferences-kubernetes.j2
     dest: /etc/apt/preferences.d/kubernetes
     mode: 0644
+
+- name: Update APT
+  apt:
+    update_cache: true
+    cache_valid_time: 86400
+    force_apt_get: true


### PR DESCRIPTION
Without this piece of code(equivalent with `apt-get update`) it won't find kubectl, kubelet, kubeadm, kubernetes-cni on a clean machine

<img width="803" alt="image" src="https://user-images.githubusercontent.com/4589309/217381649-49f85de3-10d2-4ef9-aba1-6996f71a2cc7.png">
