### PR TITLE
Ensure kernel modules are present

### DIFF
--- a/tasks/sysctl-setup.yml
+++ b/tasks/sysctl-setup.yml
@@ -7,7 +7,24 @@
     ansible_distribution != 'Debian'
     or ansible_distribution_major_version | int < 10
 
-# See: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#letting-iptables-see-bridged-traffic
+# See: https://kubernetes.io/docs/setup/production-environment/container-runtimes/#forwarding-ipv4-and-letting-iptables-see-bridged-traffic
+- name: Ensure relevant kernel module is enabled
+  modprobe:
+    name: br_netfilter
+    state: present
+  loop:
+    - br_netfilter
+    - overlay
+
+- name: Persist kernel modules after reboot
+  lineinfile:
+    path: /etc/sysctl.d/k8s.conf
+    line: "{{ item }}"
+  loop:
+    - "net.bridge.bridge-nf-call-iptables = 1"
+    - "net.bridge.bridge-nf-call-ip6tables = 1"
+    - "net.ipv4.ip_forward = 1"
+
 - name: Let iptables see bridged traffic.
   sysctl:
     name: "{{ item }}"

--- a/tasks/sysctl-setup.yml
+++ b/tasks/sysctl-setup.yml
@@ -16,6 +16,20 @@
     - br_netfilter
     - overlay
 
+- name: Check if kernel parameter file exists
+  ansible.builtin.stat:
+    path: /etc/sysctl.d/k8s.conf
+  register: kubernetes_kernel_parameter_file
+
+- name: Create kernel parameter file if it doesn't exist
+  file:
+    path: /etc/sysctl.d/k8s.conf
+    state: touch
+    owner: root
+    group: root
+    mode: 0644
+  when: kubernetes_kernel_parameter_file.stat.exists is falsy
+
 - name: Persist kernel modules after reboot
   lineinfile:
     path: /etc/sysctl.d/k8s.conf


### PR DESCRIPTION
On newly made Ubuntu 22.04(kube2) and Ubuntu 20.04 (kube1) systems, the role failed with the following error:

```
TASK [geerlingguy.kubernetes : Let iptables see bridged traffic.] ***********************************************************************************************************************************************************************************************************************************************************
failed: [kube2] (item=net.bridge.bridge-nf-call-iptables) => {"ansible_loop_var": "item", "changed": false, "item": "net.bridge.bridge-nf-call-iptables", "msg": "Failed to reload sysctl: sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: No such file or directory\nsysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-ip6tables: No such file or directory\n"}
failed: [kube1] (item=net.bridge.bridge-nf-call-iptables) => {"ansible_loop_var": "item", "changed": false, "item": "net.bridge.bridge-nf-call-iptables", "msg": "Failed to reload sysctl: sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: No such file or directory\nsysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-ip6tables: No such file or directory\n"}
failed: [kube1] (item=net.bridge.bridge-nf-call-ip6tables) => {"ansible_loop_var": "item", "changed": false, "item": "net.bridge.bridge-nf-call-ip6tables", "msg": "Failed to reload sysctl: sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: No such file or directory\nsysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-ip6tables: No such file or directory\n"}
failed: [kube2] (item=net.bridge.bridge-nf-call-ip6tables) => {"ansible_loop_var": "item", "changed": false, "item": "net.bridge.bridge-nf-call-ip6tables", "msg": "Failed to reload sysctl: sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: No such file or directory\nsysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-ip6tables: No such file or directory\n"}
```

This PR ensures that the modules are enabled and that the persist within the relevant sysctl.d directory. This mimics the documentation which can be found at https://kubernetes.io/docs/setup/production-environment/container-runtimes/#forwarding-ipv4-and-letting-iptables-see-bridged-traffic.