### PR TITLE
New apt key method

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,7 +53,7 @@ kubernetes_ignore_preflight_errors: 'all'
 
 kubernetes_apt_release_channel: main
 # Note that xenial repo is used for all Debian derivatives at this time.
-kubernetes_apt_repository: "deb http://apt.kubernetes.io/ kubernetes-xenial {{ kubernetes_apt_release_channel }}"
+kubernetes_apt_repository: "deb [signed-by=/etc/apt/trusted.gpg.d/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial {{ kubernetes_apt_release_channel }}"
 kubernetes_apt_ignore_key_error: false
 
 kubernetes_yum_arch: '$basearch'

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -10,6 +10,7 @@
   ansible.builtin.get_url:
     url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
     dest: /etc/apt/trusted.gpg.d/kubernetes-archive-keyring.gpg
+    mode: 0644
   register: add_repository_key
   ignore_errors: "{{ kubernetes_apt_ignore_key_error }}"
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -7,9 +7,9 @@
     state: present
 
 - name: Add Kubernetes apt key.
-  apt_key:
+  ansible.builtin.get_url:
     url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
-    state: present
+    dest: /etc/apt/trusted.gpg.d/kubernetes-archive-keyring.gpg
   register: add_repository_key
   ignore_errors: "{{ kubernetes_apt_ignore_key_error }}"
 


### PR DESCRIPTION
The new method for trusting gpg keys for packages uses /etc/apt/trusted.gpg.d/ rather than apt-key

https://www.jeffgeerling.com/blog/2022/aptkey-deprecated-debianubuntu-how-fix-ansible  
https://manpages.debian.org/testing/apt/apt-key.8.en.html