### PR TITLE
Added retry to networking setup

### DIFF
--- a/tasks/control-plane-setup.yml
+++ b/tasks/control-plane-setup.yml
@@ -50,18 +50,24 @@
   register: flannel_result
   changed_when: "'created' in flannel_result.stdout"
   when: kubernetes_pod_network.cni == 'flannel'
+  retries: 3
+  delay: 5
 
 - name: Configure Calico networking.
   command: "kubectl apply -f {{ kubernetes_calico_manifest_file }}"
   register: calico_result
   changed_when: "'created' in calico_result.stdout"
   when: kubernetes_pod_network.cni == 'calico'
+  retries: 3
+  delay: 5
 
 - name: Get Kubernetes version for Weave installation.
   shell: kubectl version | base64 | tr -d '\n'
   changed_when: false
   register: kubectl_version
   when: kubernetes_pod_network.cni == 'weave'
+  retries: 3
+  delay: 5
 
 - name: Configure Weave networking.
   command: "{{ item }}"


### PR DESCRIPTION
I have found, when using this role, that sometimes the networking fails to apply because the kubernetes api server is not yet ready.

This change adds a retry of up to 3 times at 5 second intervals to allow time for the API server to start up.