### PR TITLE
add missing 'until' condition in control plane setup

### DIFF
--- a/tasks/control-plane-setup.yml
+++ b/tasks/control-plane-setup.yml
@@ -51,7 +51,7 @@
   changed_when: "'created' in flannel_result.stdout"
   when: kubernetes_pod_network.cni == 'flannel'
   until: flannel_result is not failed
-  retries: 3
+  retries: 12
   delay: 5
 
 - name: Configure Calico networking.
@@ -60,7 +60,7 @@
   changed_when: "'created' in calico_result.stdout"
   when: kubernetes_pod_network.cni == 'calico'
   until: calico_result is not failed
-  retries: 3
+  retries: 12
   delay: 5
 
 - name: Get Kubernetes version for Weave installation.
@@ -69,7 +69,7 @@
   register: kubectl_version
   when: kubernetes_pod_network.cni == 'weave'
   until: kubectl_version is not failed
-  retries: 3
+  retries: 12
   delay: 5
 
 - name: Configure Weave networking.

--- a/tasks/control-plane-setup.yml
+++ b/tasks/control-plane-setup.yml
@@ -50,6 +50,7 @@
   register: flannel_result
   changed_when: "'created' in flannel_result.stdout"
   when: kubernetes_pod_network.cni == 'flannel'
+  until: flannel_result is not failed
   retries: 3
   delay: 5
 
@@ -58,6 +59,7 @@
   register: calico_result
   changed_when: "'created' in calico_result.stdout"
   when: kubernetes_pod_network.cni == 'calico'
+  until: calico_result is not failed
   retries: 3
   delay: 5
 
@@ -66,6 +68,7 @@
   changed_when: false
   register: kubectl_version
   when: kubernetes_pod_network.cni == 'weave'
+  until: kubectl_version is not failed
   retries: 3
   delay: 5
 


### PR DESCRIPTION
This PR fixes https://github.com/geerlingguy/ansible-role-kubernetes/pull/144
which introduced retries to network setup.

Unfortunately retries don't currently work due to missing `until` statement. See:
https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_loops.html#retrying-a-task-until-a-condition-is-met

> You must set the until parameter if you want a task to retry. If until is not defined, the value for the retries parameter is forced to 1.

This PR also increases the number of retries from 3 to 10; I personally did experience situations where 15 seconds were not sufficient - and I can't think of a reason to not be a bit more permissive.