### PR TITLE
Adopt `deb822_repository` format.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker] docker
+        run: pip3 install ansible molecule molecule-plugins[docker] docker debian
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker] docker debian
+        run: pip3 install ansible molecule molecule-plugins[docker] docker
 
       - name: Run Molecule tests.
         run: molecule test

--- a/README.md
+++ b/README.md
@@ -140,10 +140,11 @@ kubernetes_ignore_preflight_errors: 'all'
 Options passed to `kubeadm init` when initializing the Kubernetes control plane. The `kubernetes_apiserver_advertise_address` defaults to `ansible_default_ipv4.address` if it's left empty.
 
 ```yaml
-kubernetes_apt_repository: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/deb/"
+kubernetes_apt_release_channel: "stable"
+kubernetes_apt_repository: "https://pkgs.k8s.io/core:/{{ kubernetes_apt_release_channel }}:/v{{ kubernetes_version }}/deb/"
 ```
 
-Apt repository option for Kubernetes installation.
+Apt repository options for Kubernetes installation.
 
 ```yaml
 kubernetes_yum_base_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/rpm/"

--- a/README.md
+++ b/README.md
@@ -140,12 +140,10 @@ kubernetes_ignore_preflight_errors: 'all'
 Options passed to `kubeadm init` when initializing the Kubernetes control plane. The `kubernetes_apiserver_advertise_address` defaults to `ansible_default_ipv4.address` if it's left empty.
 
 ```yaml
-kubernetes_apt_release_channel: "stable"
-kubernetes_apt_keyring_file: "/etc/apt/keyrings/kubernetes-apt-keyring.asc"
-kubernetes_apt_repository: "deb [signed-by={{ kubernetes_apt_keyring_file }}] https://pkgs.k8s.io/core:/{{ kubernetes_apt_release_channel }}:/v{{ kubernetes_version }}/deb/ /"
+kubernetes_apt_repository: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/deb/"
 ```
 
-Apt repository options for Kubernetes installation.
+Apt repository option for Kubernetes installation.
 
 ```yaml
 kubernetes_yum_base_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/rpm/"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,7 +51,8 @@ kubernetes_apiserver_advertise_address: ''
 kubernetes_version_kubeadm: 'stable-{{ kubernetes_version }}'
 kubernetes_ignore_preflight_errors: 'all'
 
-kubernetes_apt_repository: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/deb/"
+kubernetes_apt_release_channel: "stable"
+kubernetes_apt_repository: "https://pkgs.k8s.io/core:/{{ kubernetes_apt_release_channel }}:/v{{ kubernetes_version }}/deb/"
 
 kubernetes_yum_base_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/rpm/"
 kubernetes_yum_gpg_key: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/rpm/repodata/repomd.xml.key"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,9 +51,7 @@ kubernetes_apiserver_advertise_address: ''
 kubernetes_version_kubeadm: 'stable-{{ kubernetes_version }}'
 kubernetes_ignore_preflight_errors: 'all'
 
-kubernetes_apt_release_channel: main
 kubernetes_apt_repository: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/deb/"
-kubernetes_apt_ignore_key_error: false
 
 kubernetes_yum_base_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/rpm/"
 kubernetes_yum_gpg_key: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/rpm/repodata/repomd.xml.key"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,9 +51,9 @@ kubernetes_apiserver_advertise_address: ''
 kubernetes_version_kubeadm: 'stable-{{ kubernetes_version }}'
 kubernetes_ignore_preflight_errors: 'all'
 
-kubernetes_apt_release_channel: "stable"
-kubernetes_apt_keyring_file: "/etc/apt/keyrings/kubernetes-apt-keyring.asc"
-kubernetes_apt_repository: "deb [signed-by={{ kubernetes_apt_keyring_file }}] https://pkgs.k8s.io/core:/{{ kubernetes_apt_release_channel }}:/v{{ kubernetes_version }}/deb/ /"
+kubernetes_apt_release_channel: main
+kubernetes_apt_repository: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/deb/"
+kubernetes_apt_ignore_key_error: false
 
 kubernetes_yum_base_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/rpm/"
 kubernetes_yum_gpg_key: "https://pkgs.k8s.io/core:/stable:/v{{ kubernetes_version }}/rpm/repodata/repomd.xml.key"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -16,8 +16,8 @@
     signed_by: "{{ kubernetes_apt_repository }}/Release.key"
   register: kubernetes_repository
 
-- name: 'Update Apt cache.'
-  ansible.builtin.apt:
+- name: Update Apt cache.
+  apt:
     update_cache: true
   when: kubernetes_repository.changed
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -14,6 +14,12 @@
     uris: "{{ kubernetes_apt_repository }}"
     suites: /
     signed_by: "{{ kubernetes_apt_repository }}/Release.key"
+  register: kubernetes_repository
+
+- name: 'Update Apt cache.'
+  ansible.builtin.apt:
+    update_cache: true
+    when: kubernetes_repository.changed
 
 - name: Add Kubernetes apt preferences file to pin a version.
   template:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,30 +6,13 @@
       - ca-certificates
     state: present
 
-- name: Prepare apt keyring directory.
-  ansible.builtin.file:
-    path: "{{ kubernetes_apt_keyring_file | dirname }}"
-    state: directory
-    mode: 0755
-
-- name: Get Kubernetes apt key.
-  ansible.builtin.get_url:
-    url: "https://pkgs.k8s.io/core:/{{ kubernetes_apt_release_channel }}:/v{{ kubernetes_version }}/deb/Release.key"
-    dest: "{{ kubernetes_apt_keyring_file }}"
-    mode: '0644'
-    force: true
-
-- name: Be sure deprecated Kubernetes repository is absent.
-  file:
-    path: "/etc/apt/sources.list.d/apt_kubernetes_io.list"
-    state: absent
-
 - name: Add Kubernetes repository.
-  ansible.builtin.apt_repository:
-    repo: "{{ kubernetes_apt_repository }}"
-    filename: pkgs_k8s_io
-    state: present
-    update_cache: true
+  deb822_repository:
+    name: kubernetes
+    types: deb
+    uris: "{{ kubernetes_apt_repository }}"
+    suites: /
+    signed_by: "{{ kubernetes_apt_repository }}/Release.key"
 
 - name: Add Kubernetes apt preferences file to pin a version.
   template:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -4,6 +4,7 @@
     name:
       - apt-transport-https
       - ca-certificates
+      - python3-debian
     state: present
 
 - name: Add Kubernetes repository.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -19,7 +19,7 @@
 - name: 'Update Apt cache.'
   ansible.builtin.apt:
     update_cache: true
-    when: kubernetes_repository.changed
+  when: kubernetes_repository.changed
 
 - name: Add Kubernetes apt preferences file to pin a version.
   template:


### PR DESCRIPTION
~This isn't tested, since I'm using a custom role locally, but it's a lightly edited (for code style) version of what I'm doing.~

**EDIT**: This is pretty well-tested at this point.

Unfortunately, this whole transition seems to be quite messy and may require some manual work to clear out old keys, old sources, etc if this is rerun on a cluster with the previous system in place.

To go into more detail about why this can require cleanup, the previous approach would create e.g. `/etc/apt/sources.list.d/kubernetes.list`. This creates `/etc/apt/sources.list.d/kubernes.source`, so there can be two files pointing to sources for the Kubernetes packages. This also adds the new key in a different location, so there can be multiple keys.

The problem I encountered while fighting with this and iterating while targeting a cluster was that I'd get errors like "403 forbidden" when attempting to update the apt cache. That would occur when I was using the wrong `suite` or `components` arguments, since converting from the old to the new format is IMHO kinda poorly documented. 

Then, once I got that sorted out, I had problems where my control plane was on 1.29.2 and my workers were on 1.28.2. This happened because I was working on bootstrapping my control plane (high availability, which is why I didn't use this role) and ended up iterating more on that, while my workers had received less attention. Turns out, I still had those apt-marked to pin the versions.

A sadder man, but wiser now, I open this PR for you.