### PR TITLE
Ensure Kubelet is stopped before kubeadm join command

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,10 +23,10 @@
 - include_tasks: kubelet-setup.yml  # deprecated
   when: kubernetes_kubelet_extra_args|length > 0
 
-- name: Ensure kubelet is started and enabled at boot.
+- name: Ensure kubelet is stopped, but enabled at boot.
   service:
     name: kubelet
-    state: started
+    state: stopped
     enabled: true
 
 - name: Check if Kubernetes has already been initialized.


### PR DESCRIPTION
This change ensures that the kublet is in a stopped state before running the  kubeadm join commands. This prevents preflight errors such as "Port 10250 is in use", e.g.:

![Screenshot 2024-03-07 at 10 16 41 AM](https://github.com/geerlingguy/ansible-role-kubernetes/assets/158301461/cdfdf2d2-2346-4182-8dfe-7ec227eca3e3)

This is occurring on at least Ubuntu 20 in AWS. The issue is that kubelet is running and already using port 10250 before the kubeadm join command is executed. Then, when the command is executed, it sees port 10250 is already in use by something and fails. And although it is the kubelet itself that is using the port, kubeadm doesn't seem smart enough to realize that.

I understand that I can set `kubernetes_join_command_extra_opts: "--ignore-preflight-errors=all"` to work around this issue, but I'd rather not ignore all preflight checks if possible.  There's really no need to start the kubelet the way it is currently being done.