### PR TITLE
Moves apiversions for kubeadm, kubelet, and kubeproxy from kubeadm-kubelet-config.j2 into defaults/main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,11 @@ kubernetes_pod_network:
   # cidr: '192.168.0.0/16'
 
 kubernetes_kubeadm_kubelet_config_file_path: '/etc/kubernetes/kubeadm-kubelet-config.yaml'
+
+kubernetes_config_kubeadm_apiversion: v1beta3
+kubenetes_config_kubelet_apiversion: v1beta1
+kubernetes_config_kubeproxy_apiversion: v1alpha1
+
 kubernetes_config_kubelet_configuration:
   cgroupDriver: "systemd"
 

--- a/templates/kubeadm-kubelet-config.j2
+++ b/templates/kubeadm-kubelet-config.j2
@@ -1,20 +1,20 @@
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/{{ kubernetes_config_kubeadm_apiversion }}
 kind: InitConfiguration
 {{ kubernetes_config_init_configuration | to_nice_yaml }}
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/{{ kubernetes_config_kubeadm_apiversion }}
 kind: ClusterConfiguration
 {{ kubernetes_config_cluster_configuration | to_nice_yaml }}
 {% if kubernetes_config_kubelet_configuration|length > 0 %}
 ---
-apiVersion: kubelet.config.k8s.io/v1beta1
+apiVersion: kubelet.config.k8s.io/{{ kubenetes_config_kubelet_apiversion }}
 kind: KubeletConfiguration
 {{ kubernetes_config_kubelet_configuration | to_nice_yaml }}
 {% endif %}
 {% if kubernetes_config_kube_proxy_configuration|length > 0 %}
 ---
-apiVersion: kubeproxy.config.k8s.io/v1alpha1
+apiVersion: kubeproxy.config.k8s.io/{{ kubernetes_config_kubeproxy_apiversion }}
 kind: KubeProxyConfiguration
 {{ kubernetes_config_kube_proxy_configuration | to_nice_yaml }}
 {% endif %}


### PR DESCRIPTION
apiVersions for kubeadm, the kubelet, and the kubeproxy are hardcoded in kubeadm-kubelet-config.j2. This commit parameterizes those values and moves them to main.yml so that they are no longer hardcoded.