### PR TITLE
Set minimum Ansible version for deb822_repository

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: Kubernetes for Linux.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 2.10
+  min_ansible_version: 2.15
   platforms:
     - name: Debian
       versions:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -8,7 +8,7 @@
     state: present
 
 - name: Add Kubernetes repository.
-  deb822_repository:
+  ansible.builtin.deb822_repository:
     name: kubernetes
     types: deb
     uris: "{{ kubernetes_apt_repository }}"


### PR DESCRIPTION
## Summary
- Raise min_ansible_version to 2.15 because the Debian setup path uses deb822_repository.
- Use the fully qualified ansible.builtin.deb822_repository module name.

## Validation
- With ansible-core 2.14, the Debian-family setup path fails while resolving deb822_repository.
- The failure occurs before the repository setup task can run.