### PR TITLE
Changed Default Flannel Manifest File Location

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,7 +65,7 @@ kubernetes_yum_gpg_check: true
 kubernetes_yum_repo_gpg_check: true
 
 # Flannel config file.
-kubernetes_flannel_manifest_file: https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml
+kubernetes_flannel_manifest_file: https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml
 
 # Calico config file.
 kubernetes_calico_manifest_file: https://projectcalico.docs.tigera.io/manifests/calico.yaml


### PR DESCRIPTION
Aligned the Flannel manifest file location with the file location provided in the actual repo. This should avoid issues with Flannel lagging behind what is in the Documentation/ directory, and what containers they actively have in their registry.

I ran into this issue where they updated the manifest to v0.28.6 in the Documentation/ directory on Jul 6 at 2:59PM
<img width="508" height="268" alt="image" src="https://github.com/user-attachments/assets/7c05d4b7-c48b-4325-8f39-8d47594009c6" />

But the actual container did not update until Jul 7 at 2:52PM
<img width="540" height="148" alt="image" src="https://github.com/user-attachments/assets/7a9c0a38-6ca0-4373-933b-f1649ee9524a" />

Due to this, when I tried to update the manifest in the morning of the 7th, it would fail. This change should keep everything in line.